### PR TITLE
feat(ui): Add "@" to replies with mentions

### DIFF
--- a/components/ui/components/messaging/message/Message.tsx
+++ b/components/ui/components/messaging/message/Message.tsx
@@ -51,7 +51,14 @@ export function Message(props: { message: MessageInterface; tail?: boolean }) {
                 }
               });
 
-              return <MessageReply message={message()} />;
+              return (
+                <MessageReply
+                  mention={props.message.mention_ids?.includes(
+                    message()!.author_id
+                  )}
+                  message={message()}
+                />
+              );
             }}
           </For>
         </Show>

--- a/components/ui/components/messaging/message/MessageReply.tsx
+++ b/components/ui/components/messaging/message/MessageReply.tsx
@@ -99,6 +99,7 @@ export function MessageReply(props: Props) {
               clip={props.message!.roleColour?.includes("gradient")}
             >
               <Typography variant="username">
+                {props.mention && "@"}
                 {props.message!.username}
               </Typography>
             </ColouredText>


### PR DESCRIPTION
## Please make sure to check the following tasks before opening and submitting a PR

* [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
* [x] I have tested my changes locally and they are working as intended
* [x] These changes do not have any notable side effects on other Revolt projects

This PR should close the following `issue: issue: reply pings do not include '@'`

Now shouldn't contain changes to the `assets` submodule like the last PR. (I still don't know why it committed that)
