### PR TITLE
(WIP) feat(composition): message box scaling

### DIFF
--- a/components/ui/components/messaging/composition/MessageBox.tsx
+++ b/components/ui/components/messaging/composition/MessageBox.tsx
@@ -1,5 +1,5 @@
 import { BiRegularBlock } from "solid-icons/bi";
-import { JSX, Match, Show, Switch, onMount } from "solid-js";
+import { JSX, Match, Show, Switch } from "solid-js";
 import { styled } from "solid-styled-components";
 
 import { useTranslation } from "@revolt/i18n";
@@ -105,12 +105,6 @@ export function MessageBox(props: Props) {
     props.setContent(event.currentTarget!.innerText.trim());
   }
 
-  onMount(() => {
-    if (props.ref) {
-      props.ref.innerText = props.content;
-    }
-  });
-
   return (
     <Base>
       <Switch fallback={props.actionsStart}>
@@ -126,6 +120,7 @@ export function MessageBox(props: Props) {
         fallback={
           <Input
             contenteditable={true}
+            role="textbox"
             ref={props.ref}
             onKeyDown={props.onKeyDown}
             //placeholder={props.placeholder}

--- a/components/ui/components/messaging/composition/MessageBox.tsx
+++ b/components/ui/components/messaging/composition/MessageBox.tsx
@@ -1,5 +1,5 @@
 import { BiRegularBlock } from "solid-icons/bi";
-import { JSX, Match, Show, Switch } from "solid-js";
+import { JSX, Match, Show, Switch, onMount } from "solid-js";
 import { styled } from "solid-styled-components";
 
 import { useTranslation } from "@revolt/i18n";
@@ -11,7 +11,7 @@ interface Props {
   /**
    * Ref to the input element
    */
-  ref: HTMLTextAreaElement | undefined;
+  ref: HTMLDivElement | undefined;
 
   /**
    * Text content
@@ -22,7 +22,7 @@ interface Props {
    * Handle key presses
    */
   onKeyDown: (
-    event: KeyboardEvent & { currentTarget: HTMLTextAreaElement }
+    event: KeyboardEvent & { currentTarget: HTMLDivElement }
   ) => void;
 
   /**
@@ -56,7 +56,7 @@ interface Props {
  * Message box container
  */
 const Base = styled("div", "MessageBox")`
-  height: 48px;
+  min-height: 48px;
   flex-shrink: 0;
 
   display: flex;
@@ -66,14 +66,16 @@ const Base = styled("div", "MessageBox")`
 /**
  * Input area
  */
-const Input = styled("textarea")`
+const Input = styled("div")`
   border: none;
   resize: none;
   outline: none;
   background: transparent;
 
+  max-height: 300px;
   flex-grow: 1;
   padding: 14px 0;
+  overflow-y: auto;
 
   font-family: ${(props) => props.theme!.fonts.primary};
   color: ${(props) => props.theme!.colours.foreground};
@@ -99,9 +101,15 @@ export function MessageBox(props: Props) {
    * Handle changes to input
    * @param event Event
    */
-  function onInput(event: InputEvent & { currentTarget: HTMLTextAreaElement }) {
-    props.setContent(event.currentTarget!.value);
+  function onInput(event: InputEvent & { currentTarget: HTMLDivElement }) {
+    props.setContent(event.currentTarget!.innerText.trim());
   }
+
+  onMount(() => {
+    if (props.ref) {
+      props.ref.innerText = props.content;
+    }
+  });
 
   return (
     <Base>
@@ -117,10 +125,10 @@ export function MessageBox(props: Props) {
       <Switch
         fallback={
           <Input
+            contenteditable={true}
             ref={props.ref}
             onKeyDown={props.onKeyDown}
-            value={props.content}
-            placeholder={props.placeholder}
+            //placeholder={props.placeholder}
             onInput={onInput}
           />
         }

--- a/packages/client/src/interface/channels/text/Composition.tsx
+++ b/packages/client/src/interface/channels/text/Composition.tsx
@@ -50,7 +50,7 @@ export function MessageComposition(props: Props) {
   /**
    * Reference to the message input box
    */
-  let ref: HTMLTextAreaElement | undefined;
+  let ref: HTMLDivElement | undefined;
 
   /**
    * Get the draft for the current channel
@@ -184,8 +184,10 @@ export function MessageComposition(props: Props) {
    * @param event Keyboard Event
    */
   function onKeyDownMessageBox(
-    event: KeyboardEvent & { currentTarget: HTMLTextAreaElement }
+    event: KeyboardEvent & { currentTarget: HTMLDivElement }
   ) {
+    console.log(event.currentTarget.innerText.trim());
+
     const insideCodeBlock = isInCodeBlock(event.currentTarget.selectionStart);
     const usingBracketIndent = (event.ctrlKey || event.metaKey) && (event.key === "[" || event.key === "]");
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,7 +62,7 @@ importers:
         specifier: workspace:^1.0.0
         version: link:../ui
       revolt.js:
-        specifier: workspace:^7.0.0-beta.3
+        specifier: workspace:^7.0.0-beta.4
         version: link:../../packages/revolt.js
       solid-icons:
         specifier: ^1.0.4
@@ -98,7 +98,7 @@ importers:
         specifier: workspace:^1.0.0
         version: link:../ui
       revolt.js:
-        specifier: workspace:^7.0.0-beta.3
+        specifier: workspace:^7.0.0-beta.4
         version: link:../../packages/revolt.js
       solid-hcaptcha:
         specifier: ^0.2.5
@@ -135,7 +135,7 @@ importers:
         specifier: ^6.3.2
         version: 6.6.2
       revolt.js:
-        specifier: workspace:^7.0.0-beta.3
+        specifier: workspace:^7.0.0-beta.4
         version: link:../../packages/revolt.js
       solid-js:
         specifier: ^1.7.3
@@ -227,7 +227,7 @@ importers:
         specifier: ^10.1.0
         version: 10.1.0
       revolt.js:
-        specifier: workspace:^7.0.0-beta.3
+        specifier: workspace:^7.0.0-beta.4
         version: link:../../packages/revolt.js
       solid-js:
         specifier: ^1.7.3
@@ -260,6 +260,9 @@ importers:
 
   components/modal:
     dependencies:
+      '@motionone/solid':
+        specifier: ^10.15.4
+        version: 10.15.4(solid-js@1.7.3)
       '@revolt/client':
         specifier: workspace:^1.0.0
         version: link:../client
@@ -279,7 +282,7 @@ importers:
         specifier: workspace:^1.0.0
         version: link:../ui
       revolt.js:
-        specifier: workspace:^7.0.0-beta.3
+        specifier: workspace:^7.0.0-beta.4
         version: link:../../packages/revolt.js
       solid-icons:
         specifier: ^1.0.4
@@ -311,6 +314,9 @@ importers:
       '@revolt/i18n':
         specifier: workspace:^1.0.0
         version: link:../i18n
+      '@revolt/routing':
+        specifier: workspace:^
+        version: link:../routing
       color-rgba:
         specifier: ^2.4.0
         version: 2.4.0
@@ -327,7 +333,7 @@ importers:
         specifier: ^6.3.2
         version: 6.6.2
       revolt.js:
-        specifier: workspace:^7.0.0-beta.3
+        specifier: workspace:^7.0.0-beta.4
         version: link:../../packages/revolt.js
       solid-js:
         specifier: ^1.7.3
@@ -389,7 +395,7 @@ importers:
         version: link:../../packages/solid-styled-components
     devDependencies:
       revolt.js:
-        specifier: workspace:^7.0.0-beta.3
+        specifier: workspace:^7.0.0-beta.4
         version: link:../../packages/revolt.js
 
   packages/browser-test-runner:
@@ -475,7 +481,7 @@ importers:
         specifier: ^1.1.0
         version: 1.1.0
       revolt.js:
-        specifier: workspace:^7.0.0-beta.3
+        specifier: workspace:^7.0.0-beta.4
         version: link:../revolt.js
       typescript:
         specifier: ^4.8.2


### PR DESCRIPTION
## Please make sure to check the following tasks before opening and submitting a PR

* [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
* [x] I have tested my changes locally and they are working as intended
* [x] These changes do not have any notable side effects on other Revolt projects

---

composition box now scales with input text, up to a set max-height (currently 300px). fixes #184

**this is very much a work in progress.** i'm very new to using frameworks like solidJS, and right now, i'm at a total loss as to how to progress on this. i'm posting this as a draft in case anyone is willing to give some pointers. otherwise, i am going to continue tinkering with this and get it working eventually.

### TODO:
- [ ] fix drafts not loading
- [ ] fix missing placeholder text
- [ ] fix regression in codeblock indentation
- [ ] make attachment/gif icons align to top of message box (mimics current behavior in revite)
- [ ] clean up + more/better comments