### PR TITLE
fix: Update background filter and user badges in UserSummary

### DIFF
--- a/packages/client/components/app/interface/settings/user/account/UserSummary.tsx
+++ b/packages/client/components/app/interface/settings/user/account/UserSummary.tsx
@@ -19,7 +19,7 @@ export function UserSummary(props: {
   const bannerStyle = () =>
     props.bannerUrl
       ? {
-          "background-image": `linear-gradient(rgba(255, 255, 255, 0.7), rgba(255, 255, 255, 0.7)), url("${props.bannerUrl}")`,
+          "background-image": `linear-gradient(color-mix(in srgb, var(--md-sys-color-surface-container-low) 70%, transparent), color-mix(in srgb, var(--md-sys-color-surface-container-low) 70%, transparent)), url("${props.bannerUrl}")`,
           color: 'black'
         }
       : {
@@ -99,6 +99,8 @@ const Username = styled("div", {
 
     display: "flex",
     flexDirection: "column",
+
+    color: "var(--md-sys-color-on-secondary-container)",
 
     // Display Name
     "& :nth-child(1)": {


### PR DESCRIPTION
## Please make sure to check the following tasks before opening and submitting a PR

- [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/.github/blob/master/.github/CONTRIBUTING.md)
- [x] I have tested my changes locally and they are working as intended

## Summary of Changes

This is a small PR intended to fix some of the visual discrepancies for the UserSummary modal when switching between light/dark themes.

### Original
> #### Light
> ![Screenshot From 2025-04-27 16-03-39](https://github.com/user-attachments/assets/7bd55ae7-98e6-40af-b821-a77d2b29d7d9)
> #### Dark
> ![Screenshot From 2025-04-27 16-03-47](https://github.com/user-attachments/assets/2b840488-d916-494e-bf99-93a65ddbc018)

### Updated
> #### Light
> ![Screenshot From 2025-04-27 16-03-55](https://github.com/user-attachments/assets/5f52daaf-a073-4d17-b587-5199168f2a62)
> #### Dark
> ![Screenshot From 2025-04-27 16-04-02](https://github.com/user-attachments/assets/3068b7a0-1874-418c-80b8-775603833276)

As like before, this is one of my first contributions to this repository and am not familiar with the codebase. Please let me know if there are ways in which I can improve my help.