### PR TITLE
fix: Fix/user mention object display

### DIFF
--- a/packages/client/components/ui/components/design/TextEditor.tsx
+++ b/packages/client/components/ui/components/design/TextEditor.tsx
@@ -401,7 +401,10 @@ export function TextEditor(props: Props) {
                   tr = tr.insert(
                     action.range.from,
                     schema.nodes.rfm_user_mention.createAndFill({
-                      id: match instanceof ServerMember ? match.id.user : match.id,
+                      id:
+                        match instanceof ServerMember
+                          ? match.id.user
+                          : match.id,
                       username: match.displayName ?? match.username,
                       avatar: match.animatedAvatarURL,
                     })!,

--- a/packages/client/components/ui/components/design/TextEditor.tsx
+++ b/packages/client/components/ui/components/design/TextEditor.tsx
@@ -401,8 +401,8 @@ export function TextEditor(props: Props) {
                   tr = tr.insert(
                     action.range.from,
                     schema.nodes.rfm_user_mention.createAndFill({
-                      id: match.id,
-                      username: match.displayName,
+                      id: match instanceof ServerMember ? match.id.user : match.id,
+                      username: match.displayName ?? match.username,
                       avatar: match.animatedAvatarURL,
                     })!,
                   );


### PR DESCRIPTION
## Please make sure to check the following tasks before opening and submitting a PR

- [X] I understand and have followed the [contribution guide](https://github.com/revoltchat/.github/blob/master/.github/CONTRIBUTING.md)
- [X] I have tested my changes locally and they are working as intended

I noticed on Microsoft Windows 11 and on Mac OS on edge and Firefox, when you would tag someone, their username would show up as a stringified JavaScript object. 
![Screenshot_20250812_181312_Firefox](https://github.com/user-attachments/assets/27b4183f-dbf3-4a3e-95cf-0db453289a2a)

The bug seems to be absent from Firefox on android however. 

This appears to fix it on a locally deployed instance. I figured I'd share the fix if it potentially helps.