### PR TITLE
fix: render server invites on a new line & change to joined when user is in the server

### DIFF
--- a/packages/client/components/ui/components/features/messaging/elements/Invite.tsx
+++ b/packages/client/components/ui/components/features/messaging/elements/Invite.tsx
@@ -1,4 +1,4 @@
-import { Suspense } from "solid-js";
+import { Suspense, createMemo } from "solid-js";
 
 import { useNavigate } from "@solidjs/router";
 import { useMutation, useQuery } from "@tanstack/solid-query";
@@ -37,6 +37,12 @@ export function Invite(props: Props) {
     refetchOnWindowFocus: false,
   }));
 
+  const joined = createMemo(() => {
+    if (!(query.data instanceof ServerPublicInvite)) return false;
+  
+    return client().servers?.has(query.data.serverId) ?? false;
+  });
+
   const join = useMutation(() => ({
     mutationFn: () => (query.data as ServerPublicInvite).join(),
     onSuccess(server) {
@@ -74,8 +80,8 @@ export function Invite(props: Props) {
             members
           </Text>
         </Column>
-        <Button onPress={() => join.mutate()} isDisabled={join.isPending}>
-          Join
+        <Button onPress={() => join.mutate()} isDisabled={join.isPending || joined()}>
+          {joined() ? "Joined" : "Join"}
         </Button>
       </Suspense>
     </Base>
@@ -84,7 +90,7 @@ export function Invite(props: Props) {
 
 const Base = styled("div", {
   base: {
-    display: "inline-flex",
+    display: "flex",
     alignItems: "center",
 
     width: "320px",


### PR DESCRIPTION
## Please make sure to check the following tasks before opening and submitting a PR

- [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/.github/blob/master/.github/CONTRIBUTING.md)
- [x] I have tested my changes locally and they are working as intended

## Changes 

This PR will make the server invite display the invite on a new line when text is in the message and change the join button to joined when the user is already in the server

### before
<img width="539" height="117" alt="before" src="https://github.com/user-attachments/assets/b2ff2862-387d-41f5-825c-76a6dcb6cf41" />

### after
<img width="395" height="128" alt="after" src="https://github.com/user-attachments/assets/da36b0a8-dacf-43ea-99da-c3f09224065e" />
