### PR TITLE
FIX: Show settings cog only if user has permissions

### DIFF
--- a/packages/client/src/interface/navigation/channels/ServerSidebar.tsx
+++ b/packages/client/src/interface/navigation/channels/ServerSidebar.tsx
@@ -370,26 +370,25 @@ function Entry(
               <MdPersonAdd {...iconSize("14px")} />
             </a>
 
-            <a
-              use:floating={{
-                tooltip: {
-                  placement: "top",
-                  content: "Edit Channel",
-                },
-              }}
-              onClick={(e) => {
-                e.preventDefault();
-                openModal({
-                  type: "settings",
-                  config: "channel",
-                  context: props.channel,
-                });
-              }}
-            >
-              <MdSettings {...iconSize("14px")} />
-            </a>
-          </>
-        }
+    <Show when={props.channel.server?.havePermission("ManageChannel")}>
+      <a
+        use:floating={{
+          tooltip: { placement: "top", content: "Edit Channel" },
+        }}
+        onClick={(e) => {
+          e.preventDefault();
+          openModal({
+            type: "settings",
+            config: "channel",
+            context: props.channel,
+          });
+        }}
+      >
+        <MdSettings {...iconSize("14px")} />
+      </a>
+    </Show>
+  </>
+}
       >
         <OverflowingText>
           <TextWithEmoji content={props.channel.name!} />


### PR DESCRIPTION
Haven't touched the main server settings cog as I'm not sure a way to do it which is nice (and would allow all people who'd actually need access to it to see it without looking and functioning horribly)

## Please make sure to check the following tasks before opening and submitting a PR

- [X] I understand and have followed the [contribution guide](https://github.com/revoltchat/.github/blob/master/.github/CONTRIBUTING.md)
- [X] I have tested my changes locally and they are working as intended
