### PR TITLE
FIX: Delete channel JSON error

### DIFF
--- a/packages/client/components/modal/modals/DeleteChannel.tsx
+++ b/packages/client/components/modal/modals/DeleteChannel.tsx
@@ -15,11 +15,23 @@ export function DeleteChannelModal(
   props: DialogProps & Modals & { type: "delete_channel" },
 ) {
   const { showError } = useModals();
-
-  const deleteChannel = useMutation(() => ({
-    mutationFn: () => props.channel.delete(),
-    onError: showError,
-  }));
+  
+const deleteChannel = useMutation(() => ({
+  mutationFn: async () => {
+    if (!props.channel) return;
+    try {
+      await props.channel.delete();
+    } catch (err: any) {
+      console.error("Failed to delete channel:", err);
+      if (err?.message?.includes("Unexpected end of JSON")) {
+        return;
+      }
+      throw err;
+    }
+  },
+  onSettled: () => props.onClose?.(),
+  onError: showError,
+}));
 
   return (
     <Dialog


### PR DESCRIPTION
I don't say this is a end-all solution as this issue seems to be related to the API, which might be better to fix there – But it is a temporary fix, also closes the modal upon channel deletion

## Please make sure to check the following tasks before opening and submitting a PR

- [X] I understand and have followed the [contribution guide](https://github.com/revoltchat/.github/blob/master/.github/CONTRIBUTING.md)
- [X] I have tested my changes locally and they are working as intended
