### PR TITLE
fix: Icons in friends tab dark when on dark mode

### DIFF
--- a/packages/client/components/ui/components/navigation/NavigationRail.tsx
+++ b/packages/client/components/ui/components/navigation/NavigationRail.tsx
@@ -40,6 +40,12 @@ const rail = cva({
   },
 });
 
+const Icon = cva({
+  base: {
+    fill: "var(--md-sys-color-on-surface-variant)",
+  }
+});
+
 interface ItemProps {
   value: string;
   icon: JSXElement;
@@ -52,7 +58,7 @@ interface ItemProps {
 function NavigationRailItem(props: ItemProps) {
   return (
     <mdui-navigation-rail-item value={props.value}>
-      {props.children} <div slot="icon">{props.icon}</div>
+      {props.children} <div slot="icon" class={Icon()}>{props.icon}</div>
     </mdui-navigation-rail-item>
   );
 }


### PR DESCRIPTION
## Please make sure to check the following tasks before opening and submitting a PR

- [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/.github/blob/master/.github/CONTRIBUTING.md)
- [x] I have tested my changes locally and they are working as intended

if this is not the way to do it then please let me know and ill make the changes

Closes https://github.com/revoltchat/frontend/issues/447