### PR TITLE
feat: add "Copy User ID" to UserMenu

### DIFF
--- a/packages/client/src/interface/navigation/servers/UserMenu.tsx
+++ b/packages/client/src/interface/navigation/servers/UserMenu.tsx
@@ -224,6 +224,13 @@ export function UserMenu(props: Props) {
                   <Trans>Clear status</Trans>
                 </ContextMenuButton>
               </Show>
+
+              <ContextMenuButton
+                icon={MdInfo}
+                onClick={() => navigator.clipboard.writeText(user()!.id)}
+              >
+                <Trans>Copy User ID</Trans>
+              </ContextMenuButton>
             </ContextMenu>
           </Motion>
         </Show>


### PR DESCRIPTION
Adds a "Copy User ID" selector on the user menu for ease of access
<img width="225" height="357" alt="image" src="https://github.com/user-attachments/assets/6b30bd66-0c53-4553-a0b1-f537c72d2f14" />


## Please make sure to check the following tasks before opening and submitting a PR

- [X] I understand and have followed the [contribution guide](https://github.com/revoltchat/.github/blob/master/.github/CONTRIBUTING.md)
- [X] I have tested my changes locally and they are working as intended
