### PR TITLE
fix: preserve replies when sending GIFs

### DIFF
--- a/packages/client/src/interface/channels/text/Composition.tsx
+++ b/packages/client/src/interface/channels/text/Composition.tsx
@@ -158,6 +158,14 @@ export function MessageComposition(props: Props) {
     props.onMessageSend?.();
 
     if (typeof useContent === "string") {
+      const currentDraft = draft();
+      if (currentDraft?.replies?.length) {
+        state.draft.setDraft(props.channel.id, { 
+          ...currentDraft,
+          content: useContent 
+        });
+        return state.draft.sendDraft(client(), props.channel);
+      }
       return props.channel.sendMessage(useContent);
     }
 


### PR DESCRIPTION
I'm still playing around w/ TypeScript but atleast I got to fix a Revolt bug lmao.

---

- [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/.github/blob/master/.github/CONTRIBUTING.md)
- [x] I have tested my changes locally and they are working as intended